### PR TITLE
Integrate rembg service and add image upload UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,31 @@ pnpm install
 ```
 
 ## 開発
-別ターミナルで以下を実行します。
+Next.js フロントエンドと Python 製の背景削除サービスを同時に起動します。別ターミナルで以下を実行してください。
 ```
-# Next.js フロントエンド
+# Next.js フロントエンド (http://localhost:3000)
 pnpm dev:web
 
-# rembg サービス
+# rembg サービス (http://localhost:7000)
 pnpm dev:rembg
 ```
-または一括起動:
+もしくは一括起動:
 ```
 pnpm dev:all
+```
+
+### API 呼び出し例
+`curl`:
+```
+curl -X POST -F "file=@sample.png" http://localhost:3000/api/remove-bg --output out.png
+```
+
+フロントエンドの `fetch`:
+```ts
+const formData = new FormData();
+formData.append('file', file);
+const res = await fetch('/api/remove-bg', { method: 'POST', body: formData });
+const blob = await res.blob();
 ```
 
 ## テスト

--- a/apps/web/app/api/remove-bg/route.ts
+++ b/apps/web/app/api/remove-bg/route.ts
@@ -1,17 +1,26 @@
 import { NextResponse } from 'next/server';
-import sharp from 'sharp';
 
 export async function POST(request: Request) {
-  const data = await request.formData();
-  const file = data.get('file') as File | null;
+  const formData = await request.formData();
+  const file = formData.get('file');
   if (!file) {
     return NextResponse.json({ error: 'No file provided' }, { status: 400 });
   }
-  const arrayBuffer = await file.arrayBuffer();
-  const input = Buffer.from(arrayBuffer);
-  // Placeholder: currently just returns the input without background removal
-  const output = await sharp(input).png().toBuffer();
-  return new NextResponse(output, {
+
+  const response = await fetch('http://localhost:7000/remove-bg', {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    return NextResponse.json(
+      { error: 'Failed to remove background' },
+      { status: response.status }
+    );
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  return new NextResponse(arrayBuffer, {
     headers: { 'Content-Type': 'image/png' },
   });
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,12 +1,54 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+
 export default function Home() {
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    setLoading(true);
+    setError(null);
+    setPreviewUrl(null);
+
+    try {
+      const res = await fetch('/api/remove-bg', {
+        method: 'POST',
+        body: formData,
+      });
+      if (!res.ok) {
+        throw new Error('背景削除に失敗しました');
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      setPreviewUrl(url);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-24">
+    <main className="flex min-h-screen flex-col items-center justify-center p-24 space-y-4">
       <h1 className="text-3xl font-bold">Lumina Editor</h1>
-      <div className="mt-4 space-x-4">
-        <button className="rounded bg-blue-500 px-4 py-2 text-white">背景削除</button>
-        <button className="rounded bg-green-500 px-4 py-2 text-white">サイズプリセット</button>
-        <button className="rounded bg-purple-500 px-4 py-2 text-white">書き出し</button>
-      </div>
+      <form onSubmit={handleSubmit} className="flex flex-col items-center space-y-2">
+        <input type="file" name="file" accept="image/*" required />
+        <button
+          type="submit"
+          className="rounded bg-blue-500 px-4 py-2 text-white disabled:opacity-50"
+          disabled={loading}
+        >
+          {loading ? '処理中...' : '背景削除'}
+        </button>
+      </form>
+      {error && <p className="text-red-500">{error}</p>}
+      {previewUrl && (
+        <img src={previewUrl} alt="result" className="max-w-sm" />
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- forward image upload to local rembg service and return PNG
- add client-side upload form with preview and error handling
- document concurrent dev servers and API usage examples

## Testing
- `pnpm lint` *(fails: Request was cancelled when fetching pnpm package)*
- `pnpm typecheck` *(fails: Request was cancelled when fetching pnpm package)*
- `pnpm test` *(fails: Request was cancelled when fetching pnpm package)*
- `pnpm e2e` *(fails: Request was cancelled when fetching pnpm package)*

------
https://chatgpt.com/codex/tasks/task_e_68a83acedb348331943cdab253b5a54f